### PR TITLE
HTML template add utf-8 meta tag

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -23,6 +23,7 @@ pub fn dump_html_custom<W: Write>(mut out: W, spans: &[Span]) -> IoResult<()> {
 <!doctype html>
 <html>
     <head>
+        <meta charset="utf-8">
         <style>
             html, body {{
                 width: 100%;


### PR DESCRIPTION
maybe someone will use Unicode character such as CJK words as flame comment.