### PR TITLE
WIP: fix build without json feature

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -28,6 +28,7 @@ pub fn main() {
     flame::end("render");
 
     flame::dump_html(&mut File::create("out.html").unwrap()).unwrap();
+    #[cfg(feature = "json")]
     flame::dump_json(&mut File::create("out.json").unwrap()).unwrap();
     flame::dump_stdout();
 }


### PR DESCRIPTION
I've put the json dump from the example behind a `#[cfg(..)]` so the build works. However, the threads test fails without the feature. I'll need to look deeper into this.